### PR TITLE
Add auto reset after successful guess

### DIFF
--- a/color-identifier.js
+++ b/color-identifier.js
@@ -62,6 +62,11 @@ const resultVerifier = (value, element) => {
 
         text.innerHTML = "Correct!";
         text.style.color = "rgb(0, 255, 0)";
+        
+        // Add a delay of 1.3 seconds before resetting the game automatically
+        setTimeout(() => {
+          gameGenerator();
+        }, 1300);
     }
     else {
         element.style.visibility = "hidden";


### PR DESCRIPTION
when I was playing it I realized that I hit reset all the time including when I get the correct color  
so I went ahead to add a time out of 1.3 seconds to reset it automatically after I select the right color